### PR TITLE
fix dynamic color classes in color stripe

### DIFF
--- a/src/components/common/ColorStripe.tsx
+++ b/src/components/common/ColorStripe.tsx
@@ -1,10 +1,19 @@
+import { clsx } from 'clsx';
+
 interface ColorStripe {
   text?: string,
   color: string,
 }
 
 const ColorStripe = ({ text = '', color }: ColorStripe) => (
-  <div className={`w-full bg-default-${color} text-lg text-default-white font-semibold h-full`}>
+  <div className={clsx(
+    'w-full text-lg text-default-white font-semibold h-full',
+    color === 'purple' && 'bg-default-purple',
+    color === 'pink' && 'bg-default-pink',
+    color === 'red' && 'bg-default-red',
+    color === 'orange' && 'bg-default-orange',
+
+  )}>
     {
       text && (
         <span className="pl-2">{text.toLocaleUpperCase()}</span>


### PR DESCRIPTION
fix issue with bg color classes on stripe. tailwind classes can't be concatenated with string literal